### PR TITLE
Fixing unexpected token error

### DIFF
--- a/passman.linux.sh
+++ b/passman.linux.sh
@@ -112,7 +112,7 @@ read_pass () {
     if [[ ${#info[@]} -gt 3 ]] ; then
       echo "
   Matching usernames for ${service}"
-      for (( i=0; i<((${#info[@]}/3)); i++ )) ; do
+      for (( i=0; i<${#info[@]}/3; i++ )) ; do
         # echo "  "${info[(($i*3))]} ${info[(($i*3+1))]}
         echo "  " ${info[(($i*3+1))]}
       done
@@ -226,7 +226,7 @@ delete_pass () {
      if [[ ${#info[@]} -gt 3 ]] ; then
        echo "
     Matching usernames for ${service}: "
-       for (( i=0; i<((${#info[@]}/3)); i++ )) ; do
+       for (( i=0; i<${#info[@]}/3; i++ )) ; do
          echo "  "${info[((i*3+1))]}
        done   
        read -p "
@@ -267,7 +267,7 @@ update_pass () {
     else
       echo "
   Matching usernames for ${service}: "
-      for (( i=0; i<((${#info[@]}/3)); i++ )) ; do
+      for (( i=0; i<${#info[@]}/3; i++ )) ; do
         echo "  "${info[((i*3+1))]}
       done   
       read -p "


### PR DESCRIPTION
If I start passman.linux.sh I got the following error message:

```
./passman.linux.sh: line 118: syntax error near unexpected token `newline'
./passman.linux.sh: line 118: `      done'

```

This patch fixes it.

Maybe passman.sh should also be changed, I don't use Mac.
